### PR TITLE
Changes to allow it to work with 1.8.7

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -88,7 +88,9 @@ class DashboardController < ApplicationController
 
     respond_to do |format|
       format.json do
-        render :json => @last_12_months_activity.to_a.map { |d, a|
+        render :json => @last_12_months_activity.to_a \
+        .sort{ |a,b| b[0] <=> a[0] } \
+        .map { |d, a|
           {
             :month => d.strftime("%b"),
             :distance => a[:distance],

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Bikelog::Application.config.session_store :cookie_store, key: '_bikelog_session'
+Bikelog::Application.config.session_store :cookie_store, :key => '_bikelog_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -4,7 +4,7 @@
 # which will be enabled by default in the upcoming version of Ruby on Rails.
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActionController::Base.wrap_parameters format: [:json]
+ActionController::Base.wrap_parameters :format => [:json]
 
 # Disable root element in JSON by default.
 if defined?(ActiveRecord)


### PR DESCRIPTION
Fixed the issues I could find with it not working on 1.8.7.
- Changed the ruby syntax in the initializers
- Fixed the dashboard graphs (month ordering was incorrect in 1.8.7)

Double checked that everything still worked in 1.9.2 as well.
