### PR TITLE
Fix to stop errors when a track has zero time and zero distance

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -69,6 +69,8 @@ class Track < ActiveRecord::Base
       ascent         = tp1.ascent_to_trackpoint(tp2)
       time           = tp1.time_to_trackpoint(tp2)
 
+      speed          = 0 if speed.to_s == "Infinity"
+
       self.max_speed = speed if speed > self.max_speed
       self.ascent   += ascent if ascent > 0
       self.descent  -= ascent if ascent < 0


### PR DESCRIPTION
Had this occur with one of my gpx files which has no distance and no time. When calculating the max speed it crashes out when trying to save Infinity to the database. 1.9.2 tested.
